### PR TITLE
[Do not merge yet] Update rustc-guide to rustc-dev-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ enum Foo {
 type NineStrings = [&str, 3 * 3];
 ```
 
-The Rust compiler runs the [MIR](https://rust-lang.github.io/rustc-guide/mir/index.html)
-in the [`MIR` interpreter (miri)](https://rust-lang.github.io/rustc-guide/const-eval),
+The Rust compiler runs the [MIR](https://rust-lang.github.io/rustc-dev-guide/mir/index.html)
+in the [`MIR` interpreter (miri)](https://rust-lang.github.io/rustc-dev-guide/const-eval),
 which sort of is a virtual machine using `MIR` as "bytecode".
 
 ## Table of Contents


### PR DESCRIPTION
The `rustc-guide` is being renamed to the `rustc-dev-guide`. The discussion is in rust-lang/rustc-guide#470.

This PR revises `rustc-guide` to `rustc-dev-guide` in the README

Transition tracker:  https://github.com/rust-lang/rustc-guide/issues/602
