### PR TITLE
Change rustc-dev-guide links to point to rustc-dev-guide.rust-lang.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ enum Foo {
 type NineStrings = [&str, 3 * 3];
 ```
 
-The Rust compiler runs the [MIR](https://rust-lang.github.io/rustc-dev-guide/mir/index.html)
-in the [`MIR` interpreter (miri)](https://rust-lang.github.io/rustc-dev-guide/const-eval),
+The Rust compiler runs the [MIR](https://rustc-dev-guide.rust-lang.org/mir/index.html)
+in the [`MIR` interpreter (miri)](https://rustc-dev-guide.rust-lang.org/const-eval),
 which sort of is a virtual machine using `MIR` as "bytecode".
 
 ## Table of Contents


### PR DESCRIPTION
We decided to use a different URL for the guide.  Sorry!