### PR TITLE
require CTFE to detect UB

### DIFF
--- a/rfcs/0000-const-ub.md
+++ b/rfcs/0000-const-ub.md
@@ -45,7 +45,7 @@ Other kinds of UB might or might not be detected:
 * Dereferencing unaligned pointers.
 * Violating Rust's aliasing rules.
 * Producing an invalid value (but not using it in one of the ways defined above).
-* Anything [other UB][UB] not listed here.
+* Any [other UB][UB] not listed here.
 
 All of this UB has in common that there is an "obvious" way to continue evaluation even though the program has caused UB:
 we can just access the underlying memory despite alignment and/or aliasing rules being violated, and we can just ignore the existence of an invalid value as long as it is not used in some arithmetic, logical or control-flow operation.

--- a/rfcs/0000-const-ub.md
+++ b/rfcs/0000-const-ub.md
@@ -6,7 +6,8 @@
 # Summary
 [summary]: #summary
 
-Define UB during const evaluation to lead to an unspecified result for the affected CTFE query, but not otherwise infect the compilation process.
+Define how UB during const evaluation is treated:
+some kinds of UB must be detected, the rest leads to an unspecified result for the affected CTFE query (but does not otherwise "taint" the compilation process).
 
 # Motivation
 [motivation]: #motivation
@@ -21,32 +22,50 @@ There are some values that Rust needs to compute at compile-time.
 This includes the initial value of a `const`/`static`, and array lengths (and more general, const generics).
 Computing these initial values is called compile-time function evaluation (CTFE).
 CTFE in Rust is very powerful and permits running almost arbitrary Rust code.
-This begs the question, what happens when there is `unsafe` code and it causes Undefined Behavior (UB)?
+This begs the question, what happens when there is `unsafe` code and it causes [Undefined Behavior (UB)][UB]?
 
-The answer is that in this case, the final value that is currently being executed is arbitrary.
-For example, when UB arises while computing an array length, then the final array length can be any `usize`, or it can be (partially) uninitialized memory.
-No guarantees are made about this final value, and it can be different depending on host and target architecture, compiler flags, and more.
-However, UB will not otherwise adversely affect the currently running compiler; type-checking and lints and everything else will work correctly given whatever the result of the CTFE computation is.
-
-Note, however, that this means compile-time UB can later cause runtime UB when the program is actually executed:
-for example, if there is UB while computing the initial value of a `Vec<i32>`, the result might be a completely invalid vector that causes UB at runtime when used in the program.
-
-Sometimes, the compiler might be able to detect such problems and show an error or warning about CTFE computation having gone wrong (for example, the compiler might detect when the array length ends up being uninitialized).
-But other times, this might not be the case -- UB is not reliably detected during CTFE.
+The answer depends on the kind of UB: some kinds of UB are guaranteed to be detected,
+while other kinds of UB might either be detected, or else evaluation will continue as if the violated UB condition did not exist (i.e., as if this operation was actually defined).
 This can change from compiler version to compiler version: CTFE code that causes UB could build fine with one compiler and fail to build with another.
 (This is in accordance with the general policy that unsound code is not subject to strict stability guarantees.)
+
+[UB]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-When UB arises as part of CTFE, the result of this evaluation is an unspecified constant.
-The compiler might be able to detect that UB occurred and raise an error or a warning, but this is not mandated, and absence of lints does not imply absence of UB.
+The following kinds of UB are detected by CTFE, and will cause compilation to stop with an error:
+* Incorrect use of compiler intrinsics (e.g., reaching an `unreachable` or violating the assumptions of `exact_div`).
+* Dereferencing dangling pointers.
+* Using an invalid value in an arithmetic, logical or control-flow operation.
+
+These kinds of UB have in common that there is nothing sensible evaluation can do besides stopping with an error.
+
+Other kinds of UB might or might not be detected:
+* Dereferencing unaligned pointers.
+* Violating Rust's aliasing rules.
+* Producing an invalid value (but not using it in one of the ways defined above).
+* Anything [other UB][UB] not listed here.
+
+All of this UB has in common that there is an "obvious" way to continue evaluation even though the program has caused UB:
+we can just access the underlying memory despite alignment and/or aliasing rules being violated, and we can just ignore the existence of an invalid value as long as it is not used in some arithmetic, logical or control-flow operation.
+There is no guarantee that CTFE detects such UB: evaluation may either fail with an error, or continue with the "obvious" result.
+
+## Note to implementors
+
+This requirement implies that CTFE must happen on code that was *not subject to UB-exploiting optimizations*.
+In general, optimizations of Rust code may assume that the source program does not have UB, so programs that exhibit UB can simply be ignored when arguing for the correctness of an optimization.
+However, this can lead to programs with UB being translated into programs without UB, so if constant evaluation runs after such an optimization, it might fail to detect the UB.
+The only permissible optimizations are those that preserve all UB and that preserve the behavior of programs whose UB CTFE does not detect.
+Formally speaking this means they must be correct optimizations for the abstract machine *that CTFE actually implements*, not just for the abstract machine that specifies Rust; and moreover they must preserve the location and kind of UB that is detected by CTFE.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-This means UB during CTFE can silently "corrupt" the build in a way that the final program has UB when being executed
-(but not more so than if the CTFE code would instead have been run at runtime).
+To be able to either detect UB or continue evaluation in a well-defined way, CTFE must run on unoptimized code.
+This means when compiling a `const fn` in some crate, the unoptimized code needs to be stored.
+So either the code is stored twice (optimized and unoptimized), or optimizations can only happen after all CTFE results have been computed.
+[Experiments in rustc](https://perf.rust-lang.org/compare.html?start=35debd4c111610317346f46d791f32551d449bd8&end=3dbdd3b981f75f965ac04452739653a3d47ff0ed) showed a severe performance impact on CTFE stress-tests, but no impact on real code except for a slowdown of "incr-unchanged" (which are rather fast so small changes lead to large percentages).
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -54,9 +73,11 @@ This means UB during CTFE can silently "corrupt" the build in a way that the fin
 The most obvious alternative is to say that UB during CTFE will definitely be detected.
 However, that is expensive and might even be impossible.
 Even Miri does not currently detect all UB, and Miri is already performing many additional checks that would significantly slow down CTFE.
-Furthermore, since optimizations can "hide" UB (an optimization can turn a program with UB into one without), this means we would have to run CTFE on unoptimized MIR.
-And finally, implementing these checks requires a more precise understanding of UB than we currently have; basically, this would block having any potentially-UB operations at const-time on having a spec for Rust that precisely describes their UB in a checkable way.
+Furthermore, implementing these checks requires a more precise understanding of UB than we currently have; basically, this would block having any potentially-UB operations at const-time on having a spec for Rust that precisely describes their UB in a checkable way.
 In particular, this would mean we need to decide on an aliasing model before permitting raw pointers in CTFE.
+
+To avoid the need for keeping the unoptimized sources of `const fn` around, we could weaken the requirement for detecting UB and instead say that UB might cause arbitrary evaluation results.
+Under the assumption that unsound code is not subject to the usual stability guarantees, this is an option we can still move to in the future, should it turn out that the proposal made in this RFC is too expensive.
 
 Another extreme alternative would be to say that UB during CTFE may have arbitrary effects in the host compiler, including host-level UB.
 Basically this would mean that CTFE would be allowed to "leave its sandbox".
@@ -68,11 +89,9 @@ While compiling untrusted code should only be done with care (including addition
 
 C++ requires compilers to detect UB in `constexpr`.
 However, the fragment of C++ that is available to `constexpr` excludes pointer casts, pointer arithmetic (beyond array bounds), and union-based type punning, which makes such checks not very complicated and avoids most of the poorly specified parts of UB.
-
-If we found a way to run CTFE on unoptimized MIR, then detecting UB for programs that do not use unions, `transmute`, or raw pointers is not very hard.
-CTFE already has almost all the checks required for this, except for alignment checks which are disabled during CTFE.
-(Disabling them was the easiest way forward to solve some issues around packed structs in patterns, but we could use a different solution and reinstate CTFE alignment checks.
-The relevant code paths still exist for Miri.)
+The corresponding type-punning-free fragment of Rust (no raw pointers, no `union`, no `transmute`) can only cause UB that is defined UB to be definitely detected during CTFE.
+In that sense, rust achieves feature parity with C++ in terms of UB detection during CTFE.
+(Indeed, this was the prime motivation for making such strict UB detection requirements in the first place.)
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
@@ -84,5 +103,4 @@ Currently none.
 
 This RFC provides an easy way forward for "unconst" operations, i.e., operations that are safe at run-time but not at compile-time.
 Primary examples of such operations are anything involving the integer representation of pointers, which cannot be known at compile-time.
-If this RFC were accepted, we could declare such operations UB during CTFE (and thus naturally they would only be permitted in an `unsafe` block).
-This still leaves the door open for providing better guarantees in the future.
+If this RFC were accepted, we could declare such operations "definitely detected UB" during CTFE (and thus naturally they would only be permitted in an `unsafe` block).

--- a/rfcs/0000-const-ub.md
+++ b/rfcs/0000-const-ub.md
@@ -51,6 +51,12 @@ All of this UB has in common that there is an "obvious" way to continue evaluati
 we can just access the underlying memory despite alignment and/or aliasing rules being violated, and we can just ignore the existence of an invalid value as long as it is not used in some arithmetic, logical or control-flow operation.
 There is no guarantee that CTFE detects such UB: evaluation may either fail with an error, or continue with the "obvious" result.
 
+If the compile-time evaluation uses operations that are specified as non-deterministic,
+and only some of the non-deterministic choices lead to CTFE-detected UB,
+then CTFE may choose any possible execution and thus miss the possible UB.
+For example, if we end up specifying the value of padding after a typed copy to be non-deterministically chosen, then padding will be initialized in some executions and uninitialized in others.
+If the program then performs integer arithmetic on a padding byte, that might or might not be detected as UB, depending on the non-deterministic choice made by CTFE.
+
 ## Note to implementors
 
 This requirement implies that CTFE must happen on code that was *not subject to UB-exploiting optimizations*.


### PR DESCRIPTION
This is what @oli-obk and me agreed on [here](https://github.com/rust-lang/const-eval/pull/58#discussion_r508290645), except I went one step further and now require that for non-detected UB, CTFE continues in a reasonable way, instead of producing an arbitrary result. Once we keep the unoptimized MIR around, that is cheap to do. For example, this means that when the code violates alignment, CTFE must either raise an error or continue as if the pointer was actually well-aligned (and perform the appropriate load from the given region of memory). The previous wording would have allowed CTFE to return `Undef` when loading from an unaligned pointer -- I cannot see a good reason why we would permit CTFE to do that.