### PR TITLE
fix const: dynamic checks for accessing statics

### DIFF
--- a/const.md
+++ b/const.md
@@ -128,4 +128,5 @@ observing the fact that it has been "deduplicated"), this here is about using
 such a value at compile-time even though it might be changed at run-time.
 
 *Dynamic check.* The Miri engine checks this dynamically by refusing to access
-global memory when computing a const.
+global mutable memory, and refusing to dereference any pointer to a static, when
+computing a const.


### PR DESCRIPTION
Somehow the `mutable` got lost in https://github.com/rust-lang/const-eval/pull/34, and I am not sure why...

The current rules are [implemented here](https://github.com/rust-lang/rust/blob/86545224be4e233e11948b23851dc915319c4658/compiler/rustc_const_eval/src/const_eval/machine.rs#L494).